### PR TITLE
Fix favicon path

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,7 +6,7 @@ module.exports = {
   baseUrl: '/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
-  favicon: 'img/favicon.png',
+  favicon: 'img/logo.png',
   organizationName: 'yewstack', // Usually your GitHub org/user name.
   projectName: 'yew', // Usually your repo name.
   themeConfig: {


### PR DESCRIPTION
#### Description

When visiting [https://yew.rs/](https://yew.rs/) the browser is inable to load a favicon. This is due to it being directed to [`/img/favicon.png`](https://yew.rs/img/favicon.png), which doesn't exist.

To address this, I changed the path to [`/img/logo.png`](https://yew.rs/img/logo.png), which already exists.

#### Checklist

<!-- For further details, please read CONTRIBUTING.md -->

- [ ] ~I have run `cargo make pr-flow`~ not applicable (I think?)
- [x] I have reviewed my own code
- [ ] ~I have added tests~ not applicable
